### PR TITLE
POSIX incompatibility issue.

### DIFF
--- a/docker-entrypoint-template
+++ b/docker-entrypoint-template
@@ -7,13 +7,21 @@ set -e
 
 defaultArgs=" --logfile /proc/self/fd/1 --watchdog-foreground --address=$(hostname):31339"
 
-# this if will check if the first argument is a flag
-if [ "${1:0:1}" = '-' ]; then
-  set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
-elif [ "$1" = '/usr/bin/newrelic-daemon' ]; then
-  # Remove the first element from the arguments
-  shift 1
-  set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
-fi
+case "$1" in
+  -*)
+    #args start with a flag
+        echo "case one"
+    set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
+    ;;
+  '/usr/bin/newrelic-daemon')
+    # Remove the first element from the arguments
+    shift 1
+    set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
+    ;;
+  *)
+    #likely invalid args, but the daemon will handle it with graceful messages.
+    set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
+    ;;
+esac
 
 exec "$@"

--- a/docker-entrypoint-template
+++ b/docker-entrypoint-template
@@ -10,7 +10,6 @@ defaultArgs=" --logfile /proc/self/fd/1 --watchdog-foreground --address=$(hostna
 case "$1" in
   -*)
     #args start with a flag
-        echo "case one"
     set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
     ;;
   '/usr/bin/newrelic-daemon')


### PR DESCRIPTION
The following line was POSIX incompatible because in POSIX sh string indexing is undefined:

`if [ "${1:0:1}" = '-' ];`

The logic has been replaced with POSIX sh compatible logic.

This new logic has been tested to work using the tests in `test/image_tests.sh`.