### PR TITLE
Restore functionality in docker entrypoint

### DIFF
--- a/docker-entrypoint-template
+++ b/docker-entrypoint-template
@@ -7,13 +7,21 @@ set -e
 
 defaultArgs=" --logfile /proc/self/fd/1 --watchdog-foreground --address=$(hostname):31339"
 
-# this if will check if the first argument is a flag
-if [ "${1:0:1}" = '-' ]; then
-  set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
-elif [ "$1" = '/usr/bin/newrelic-daemon' ]; then
-  # Remove the first element from the arguments
-  shift 1
-  set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
-fi
+case "$1" in
+  -*)
+    #args start with a flag
+        echo "case one"
+    set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
+    ;;
+  '/usr/bin/newrelic-daemon')
+    # Remove the first element from the arguments
+    shift 1
+    set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
+    ;;
+  *)
+    #likely invalid args, but the daemon will handle it with graceful messages.
+    set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
+    ;;
+esac
 
 exec "$@"

--- a/docker-entrypoint-template
+++ b/docker-entrypoint-template
@@ -10,7 +10,6 @@ defaultArgs=" --logfile /proc/self/fd/1 --watchdog-foreground --address=$(hostna
 case "$1" in
   -*)
     #args start with a flag
-        echo "case one"
     set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
     ;;
   '/usr/bin/newrelic-daemon')

--- a/docker-entrypoint-template
+++ b/docker-entrypoint-template
@@ -17,10 +17,6 @@ case "$1" in
     shift 1
     set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
     ;;
-  *)
-    #likely invalid args, but the daemon will handle it with graceful messages.
-    set -- /usr/bin/newrelic-daemon $defaultArgs "$@"
-    ;;
 esac
 
 exec "$@"

--- a/tests/image-tests.sh
+++ b/tests/image-tests.sh
@@ -52,6 +52,11 @@ run_tests() {
   docker run -d --name $name -v $PWD/newrelic.cfg:/etc/newrelic/newrelic.cfg c-daemon --c /etc/newrelic/newrelic.cfg
   verify_output $name "set the loglevel to debug using cfg file" -n "$(docker logs $name | grep Debug)"
 
+  name=other-cmd
+  docker run -d --name $name c-daemon pwd
+  verify_output $name "test another command not preceded by a flag is run" -n "$(docker logs $name | grep '/')"
+
+
 }
 
 versions=$(find . -maxdepth 1 -type d -name '[0-9]*' -exec basename {} \;)


### PR DESCRIPTION
In speaking further with Johannes, he recalled the original functionality allowed for starting something in the container that was not our daemon.

I removed the last clause of the case statement to not assume that our daemon will be run and to allow the caller to run another command besides newrelic-daemon.  It functionally behaves like the previous (non POSIX compatible) entry point.  

However…
The functionality of this(old and new) is somewhat limited because it only works for commands that don't use preceding flags.  For instance, both instances can run a command the following:
```
  docker build -t c-daemon .
  name=temp
  docker run -d --name $name c-daemon ls
  docker logs $name
```
  and
```
  docker build -t c-daemon .
  name=temp
  docker run -d --name $name c-daemon ls -l
  docker logs $name
```
And you'll see the output in the logs.  However, if you try to call any command that uses flags preceding the command, like:
```
docker run -d --name $name c-daemon -lt /bin/sh
```
We call the newrelic daemon with all flags and anything following the flags, so we'd call `newrelic-daemon` with `-lt /bin/sh` arguments.

The three use cases are then:
	.	Running the daemon with the full path: `docker run -d --name $name c-daemon /usr/bin/newrelic-daemon --loglevel debug`
	.	Running the daemon without specifying the daemon binary: `docker run -d --name $name c-daemon --loglevel debug`
	.	Running an arbitrary command that is NOT preceded by a flag: `docker run -d --name $name c-daemon cat /var/log/newrelic-daemon.log`

This has been tested by `tests/image_tests.sh`.

`image_tests.sh` has also been updated to test functionality of usage case #3.