### PR TITLE
Update push-docker-image.bash

### DIFF
--- a/tools/push-docker-image.bash
+++ b/tools/push-docker-image.bash
@@ -8,6 +8,6 @@ cd ${version} || exit 1
 
 docker build -t newrelic/php-daemon:latest -t newrelic/php-daemon:${version} .
 
-docker login --username=newrelicphp --password ${DOCKER_HUB_PASSWORD}
+docker login --username=newrelicphp --password ${DOCKER_HUB_PAT}
 
 docker push newrelic/php-daemon


### PR DESCRIPTION
With the stricter authentication to docker hub, we need to use a personal access token, not the password.