### PR TITLE
ci: add workflows to create and push docker images

### DIFF
--- a/.github/workflows/create-new-dockerfile.yml
+++ b/.github/workflows/create-new-dockerfile.yml
@@ -12,8 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Create new dockerfile and push branch
+        env:
+          DOWNLOAD_URL: ${{ secrets.DOWNLOAD_URL }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          TESTING_BUCKET=${{ secrets.TESTING_BUCKET }}
           ./tools/update-docker-image.bash ${{ inputs.version }}

--- a/.github/workflows/create-new-dockerfile.yml
+++ b/.github/workflows/create-new-dockerfile.yml
@@ -1,4 +1,4 @@
-name: create-new-image
+name: create-new-dockerfile
 
 on:
   workflow_dispatch:
@@ -7,11 +7,11 @@ on:
         required: true
 
 jobs:
-  create-new-image:
+  create-new-dockerfile:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Create new docker image and push branch
+      - name: Create new dockerfile and push branch
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/create-new-image.yml
+++ b/.github/workflows/create-new-image.yml
@@ -1,0 +1,19 @@
+name: create-new-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+
+jobs:
+  create-new-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create new docker image and push branch
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          TESTING_BUCKET=${{ secrets.TESTING_BUCKET }}
+          ./tools/update-docker-image.bash ${{ inputs.version }}

--- a/.github/workflows/pr_runner.yml
+++ b/.github/workflows/pr_runner.yml
@@ -25,10 +25,16 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      # Get the branch name so that we know which version to run CI on
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=$(echo ${GITHUB_HEAD_REF})" >>$GITHUB_OUTPUT
+        id: extract_branch
+
       # Runs the test scripts using the runner's shell
       - name: Run tests
         run: |
           echo Running tests 
           chmod +x ./tests/image-tests.sh
-          ./tests/image-tests.sh
+          ./tests/image-tests.sh ${{ steps.extract_branch.outputs.branch }}
         shell: bash

--- a/.github/workflows/push-new-image.yml
+++ b/.github/workflows/push-new-image.yml
@@ -7,7 +7,7 @@ on:
         required: true
 
 jobs:
-  create-new-image:
+  push-new-image:
     runs-on: ubuntu-latest
     steps:
       - name: Extract short version

--- a/.github/workflows/push-new-image.yml
+++ b/.github/workflows/push-new-image.yml
@@ -1,0 +1,29 @@
+name: push-new-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+
+jobs:
+  create-new-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract short version
+        run: |
+          version_short=$(echo ${{ inputs.version }} | awk -F "." '{print $1 "." $2 "." $3}')
+          echo "version_short=$version_short" >> $GITHUB_ENV
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_WRITE_PAT }}
+      - name: Build and Push
+        uses: docker/build-push-action@v4
+        with:
+          context: "{{defaultContext}}:${{ env.version_short }}"
+          push: true
+          tags: newrelic/php_daemon:latest,newrelic/php_daemon:${{ env.version_short }} 

--- a/tests/image-tests.sh
+++ b/tests/image-tests.sh
@@ -60,11 +60,19 @@ run_tests() {
 
 }
 
-versions=$(find . -maxdepth 1 -type d -name '[0-9]*' -exec basename {} \;)
-for dir in ${versions}; do
-  pushd $dir
-  run_tests $dir
+version=$1
+
+if [[ -z $version || ! -d $version ]]; then
+  versions=$(find . -maxdepth 1 -type d -name '[0-9]*' -exec basename {} \;)
+  for dir in ${versions}; do
+    pushd $dir
+    run_tests $dir
+    popd
+  done
+else
+  pushd $version
+  run_tests $version
   popd
-done
+fi
 
 exit

--- a/tools/update-docker-image.bash
+++ b/tools/update-docker-image.bash
@@ -9,7 +9,7 @@ fi
 version=$1
 version_short=$(echo $1 | awk -F "." '{print $1 "." $2 "." $3}')
 
-wget -O /tmp/newrelic-php5-${version}-linux-musl.tar.gz https://download.newrelic.com/php_agent/archive/${version}/newrelic-php5-${version}-linux-musl.tar.gz;
+wget -O /tmp/newrelic-php5-${version}-linux-musl.tar.gz ${TESTING_BUCKET}/newrelic-php5-${version}-linux-musl.tar.gz;
 
 sha=$(sha256sum /tmp/newrelic-php5-${version}-linux-musl.tar.gz | awk '{print $1}')
 

--- a/tools/update-docker-image.bash
+++ b/tools/update-docker-image.bash
@@ -26,3 +26,6 @@ sed \
 git checkout -b $version_short
 git add .
 git commit -m "version bump to ${version_short}"
+git tag -a v$version_short -m "GHA created tag"
+git push origin HEAD
+git push origin --tags

--- a/tools/update-docker-image.bash
+++ b/tools/update-docker-image.bash
@@ -9,7 +9,7 @@ fi
 version=$1
 version_short=$(echo $1 | awk -F "." '{print $1 "." $2 "." $3}')
 
-wget -O /tmp/newrelic-php5-${version}-linux-musl.tar.gz ${TESTING_BUCKET}/newrelic-php5-${version}-linux-musl.tar.gz;
+wget -O /tmp/newrelic-php5-${version}-linux-musl.tar.gz ${DOWNLOAD_URL}/newrelic-php5-${version}-linux-musl.tar.gz;
 
 sha=$(sha256sum /tmp/newrelic-php5-${version}-linux-musl.tar.gz | awk '{print $1}')
 


### PR DESCRIPTION
Makes the PR-runner only run verification on the new Dockerfiles, assuming the PR branch matches the directory with the new file.
Also adds 2 additional workflows to automate the creation of daemon docker images.

create workflow:
  - now uses the testing bucket instead of release bucket. This allows us to create and test the image earlier in the release cycle
 
push workflow:
  - now uses docker-actions instead of the local bash script. This choice offers more secrets security.
  - no longer needs the version_short input, as it creates the short version same as the create workflow.

Future considerations (the goal of this PR is just to achieve feature parity):
  - have the create workflow also make the PR with the new Dockerfile
  - add a workflow to automatically remove the branch/tag/PR in case that we need to change the testing condidate
  - Add a workflow to remove old Dockerfiles OR do not store the old Dockerfiles and instead make the version a parameter to the build