### PR TITLE
ci(new docker): last version digit can be 1+

### DIFF
--- a/tools/update-docker-image.bash
+++ b/tools/update-docker-image.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-if [[ ! "$1" =~ [0-9]+\.[0-9]+\.[0-9]+\.[0-9]{3} ]]; then
+if [[ ! "$1" =~ [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]]; then
   echo "ERROR: A full version string must be passed in"
   exit 1
 fi


### PR DESCRIPTION
The last digit of the version was requiring 3 digits.  It needs min one digit.