### PR TITLE
chore: update workflows to use the version of actions that are running on Node 20

### DIFF
--- a/.github/workflows/create-new-dockerfile.yml
+++ b/.github/workflows/create-new-dockerfile.yml
@@ -10,7 +10,7 @@ jobs:
   create-new-dockerfile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create new dockerfile and push branch
         env:
           DOWNLOAD_URL: ${{ secrets.DOWNLOAD_URL }}

--- a/.github/workflows/pr_runner.yml
+++ b/.github/workflows/pr_runner.yml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Get the branch name so that we know which version to run CI on
       - name: Extract branch name

--- a/.github/workflows/push-new-image.yml
+++ b/.github/workflows/push-new-image.yml
@@ -15,14 +15,14 @@ jobs:
           version_short=$(echo ${{ inputs.version }} | awk -F "." '{print $1 "." $2 "." $3}')
           echo "version_short=$version_short" >> $GITHUB_ENV
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_WRITE_PAT }}
       - name: Build and Push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: "{{defaultContext}}:${{ env.version_short }}"
           push: true


### PR DESCRIPTION
This PR ensures that workflows use the version of actions that are running on Node 20.

Actions upgraded:

- actions/checkout@v2 -> v4: https://github.com/actions/checkout/releases/tag/v4.0.0
- actions/checkout@v3 -> v4: https://github.com/actions/checkout/releases/tag/v4.0.0
- docker/login-action@v2 -> v3: https://github.com/docker/login-action/releases/tag/v3.0.0
- docker/setup-buildx@v2 -> v3: https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0
- docker/build-push-action@v4 -> v5: https://github.com/docker/build-push-action/releases/tag/v5.0.0