### PR TITLE
ci: add security scan with trivy

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,45 @@
+name: Security scan
+on:
+  # Run only on version bump pull requests that modify Dockerfile
+  pull_request:
+    paths:
+      - '**/Dockerfile'
+    branches:
+      - '[1-9]+.[0-9]+.[0-9]+'
+  schedule:
+    - cron: '0 9 * * *' # Same time as CI Cron
+
+jobs:
+  trivy-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Run Trivy in table mode
+        # Table output is only useful when running on a pull request or push.
+        if: contains(fromJSON('["pull_request"]'), github.event_name)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: ./newrelic-php-daemon-docker/${{ github.ref_name }}
+          trivy-config: ./newrelic-php-daemon-docker/trivy.yaml
+          format: table
+          exit-code: 1
+
+      - name: Run Trivy in report mode
+        # Only generate sarif when running nightly
+        if: ${{ github.event_name == 'schedule' }}
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: image
+          scan-ref: newrelic/php-daemon:latest
+          trivy-config: ./newrelic-php-daemon-docker/trivy.yaml
+          format: sarif
+          output: trivy-results.sarif
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        # Only upload sarif when running nightly
+        if: ${{ github.event_name == 'schedule' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,17 @@
+db:
+  repository:
+    - mirror.gcr.io/aquasec/trivy-db:2
+
+scan:
+  scanners: 
+    - vuln
+    - misconfig
+
+severities:
+  - CRITICAL
+  - HIGH
+  - MEDIUM
+  - LOW
+
+vulnerability:
+  ignore-unfixed: true


### PR DESCRIPTION
Security scan with trivy will be run on version bump pull requests that modify Dockerfile, and daily. trivy scan configuration is stored in a file to ensure the same configuration is used regardless if trivy is run as GitHub action or when trivy is used locally.