### PR TITLE
ci: fix security scan workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,8 +22,8 @@ jobs:
         uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: fs
-          scan-ref: ./newrelic-php-daemon-docker/${{ github.ref_name }}
-          trivy-config: ./newrelic-php-daemon-docker/trivy.yaml
+          scan-ref: ./${{ github.ref_name }}
+          trivy-config: ./trivy.yaml
           format: table
           exit-code: 1
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,13 +1,14 @@
 name: Security scan
 on:
-  # Run only on version bump pull requests that modify Dockerfile
-  pull_request:
+  # Run only on pushes to version bump pull requests that modify Dockerfile
+  push:
     paths:
       - '**/Dockerfile'
     branches:
       - '[1-9]+.[0-9]+.[0-9]+'
+  # Run nightly
   schedule:
-    - cron: '0 9 * * *' # Same time as CI Cron
+    - cron: '0 9 * * *'
 
 jobs:
   trivy-scan:
@@ -17,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Run Trivy in table mode
         # Table output is only useful when running on a pull request or push.
-        if: contains(fromJSON('["pull_request"]'), github.event_name)
+        if: contains(fromJSON('["push"]'), github.event_name)
         uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: fs


### PR DESCRIPTION
The workflow actually needs to run on **push** event with branch and path
filtering rules applied and not pull_request. This approach ensures that
the workflow runs only when needed - updates to `Dockerfile` in version
bump pull requests.