### PR TITLE
ci: improve stability of scheduled security scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           scan-type: image
           scan-ref: newrelic/php-daemon:latest
-          trivy-config: ./newrelic-php-daemon-docker/trivy.yaml
+          trivy-config: ./trivy.yaml
           format: sarif
           output: trivy-results.sarif
 


### PR DESCRIPTION
By default repository code is checked out to current working directory and that's where trivy needs to look for its configuration file which configures the trivy db location.