### PR TITLE
Fix/fixes docker deprecations

### DIFF
--- a/Dockerfile-template
+++ b/Dockerfile-template
@@ -7,7 +7,7 @@
 FROM alpine:3.21 AS build
 
 ENV NEWRELIC_VERSION
-ENV NEWRELIC_NAME newrelic-php5-${NEWRELIC_VERSION}-linux-musl
+ENV NEWRELIC_NAME=newrelic-php5-${NEWRELIC_VERSION}-linux-musl
 ENV NEWRELIC_SHA
 
 RUN set -ex; \

--- a/tools/update-docker-image.bash
+++ b/tools/update-docker-image.bash
@@ -19,8 +19,8 @@ cp docker-entrypoint-template $version_short/docker-entrypoint.sh
 cd $version_short
 
 sed \
-   -e s/"ENV[[:space:]]NEWRELIC_VERSION/ENV NEWRELIC_VERSION ${version}"/ \
-   -e s/"ENV[[:space:]]NEWRELIC_SHA/ENV NEWRELIC_SHA ${sha}"/ \
+   -e s/"ENV[[:space:]]NEWRELIC_VERSION/ENV NEWRELIC_VERSION=${version}"/ \
+   -e s/"ENV[[:space:]]NEWRELIC_SHA/ENV NEWRELIC_SHA=${sha}"/ \
     ../Dockerfile-template > Dockerfile
 
 git checkout -b $version_short


### PR DESCRIPTION
The recommended form of an ENV statement should use an "=" instead of a space.