### PR TITLE
security: Bump Alpine version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,10 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "security:"

--- a/Dockerfile-template
+++ b/Dockerfile-template
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 
 
-FROM alpine:3.21 AS build
+FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS build
 
 ENV NEWRELIC_VERSION
 ENV NEWRELIC_NAME=newrelic-php5-${NEWRELIC_VERSION}-linux-musl
@@ -18,7 +18,7 @@ RUN set -ex; \
         export NR_INSTALL_SILENT=1; \
         ${NEWRELIC_NAME}/newrelic-install install_daemon
 
-FROM alpine:3.21
+FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 # The daemon needs certs installed to run
 RUN apk add --no-cache \


### PR DESCRIPTION
Bump Alpine in Dockerfile-template to address OS package security
vulnerabilities detected by security scan.

Automate Alpine base image update PRs to keep daemon docker image up to date.
This configuration will only pick up Dockerfile-template from repos root dir.